### PR TITLE
Add publish to pypi action

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -9,6 +9,24 @@ on:
       - 'v[0-9]+.[0-9]+.*'
 
 jobs:
+  check-tag:
+    name: Check Tag
+    if: github.ref_type == 'tag' # only publish to PyPI on tag pushes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Tag
+        id: check-tag
+        run: |
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "PEP_0440_final_match=true" >> $GITHUB_OUTPUT
+          fi
+          if [[ ${{ github.event.ref }} =~ ^refs\/tags\/v([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?$ ]]; then
+              echo "PEP_0440_match=true" >> $GITHUB_OUTPUT
+          fi
+    outputs:
+      PEP_0440_final_match: ${{ steps.check-tag.outputs.PEP_0440_final_match }}
+      PEP_0440_match: ${{ steps.check-tag.outputs.PEP_0440_match }}
+
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
@@ -37,8 +55,9 @@ jobs:
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
-    if: github.ref_type == 'tag' # only publish to PyPI on tag pushes
+    if: needs.check-tag.outputs.PEP_0440_final_match == 'true'
     needs:
+      - check-tag
       - build
     runs-on: ubuntu-latest
     environment:
@@ -50,17 +69,20 @@ jobs:
       - name: Check Tag
         id: check-tag
         run: |
-          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "match=true" >> $GITHUB_OUTPUT
+          if [[ ${{ github.event.ref }} =~ /^refs\/tags\/v(\d+\.\d+\.\d+)$/ ]]; then
+              echo "PEP_0440_final_match=true" >> $GITHUB_OUTPUT
+          fi
+          if [[ ${{ github.event.ref }} =~ /^refs\/tags\/v?(?:(\d+)!)?(\d+)(\.\d+)*((a|b|rc)\d+)?(\.post\d+)?(\.dev\d+)?(\+.+)?$/ ]]; then
+              echo "PEP_0440_match=true" >> $GITHUB_OUTPUT
           fi
       - name: Download all the dists
-        if: steps.check-tag.outputs.match == 'true'
+        if: steps.check-tag.outputs.PEP_0440_final_match == 'true'
         uses: actions/download-artifact@v3
         with:
           name: python-package-distributions
           path: dist/
       - name: Publish distribution 📦 to PyPI
-        if: steps.check-tag.outputs.match == 'true'
+        if: steps.check-tag.outputs.PEP_0440_final_match == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
 
   github-release:
@@ -108,8 +130,9 @@ jobs:
 
   publish-to-testpypi:
     name: Publish Python 🐍 distribution 📦 to TestPyPI
-    if: github.ref_type == 'tag'
+    if: needs.check-tag.outputs.PEP_0440_match == 'true'
     needs:
+      - check-tag
       - build
     runs-on: ubuntu-latest
 

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,4 +1,19 @@
-# https://docs.github.com/zh/actions/using-workflows/workflow-syntax-for-github-actions
+# File Explanation:
+
+#   This GitHub Actions workflow is designed to automate the process of publishing Python packages to PyPI and TestPyPI, triggered by tags, and executed only when pushing code with version tags. Here's the purpose of each step in the workflow:
+
+#   1. **Check Tag**: Verifies if the pushed tag complies with the PEP 440 versioning specification to determine whether it should be published to PyPI or TestPyPI. If the tag complies with the specification, it outputs the results indicating compliance.
+
+#   2. **Build distribution**: Builds binary wheels and source code tarballs of Python packages on an Ubuntu environment and stores the built distribution packages in the `dist/` directory.
+
+#   3. **Publish to PyPI**: If the tag represents a final version according to the PEP 440 specification, the built distribution packages are published to PyPI. This step downloads the distribution packages and publishes them to PyPI. This step requires `PEP_0440_final_match` to be `true`.
+
+#   4. **Sign the Python distribution with Sigstore and upload them to GitHub Release**: Signs the Python distribution packages with Sigstore and uploads them to GitHub Release. This step requires successful execution of the previous step to publish to PyPI and needs GitHub permissions for content writing. The signed distribution packages and certificates are uploaded as part of the release.
+
+#   5. **Publish to TestPyPI**: If the tag complies with the PEP 440 specification but is not a final version, such as containing development versions or pre-release versions, the built distribution packages are published to TestPyPI. This step downloads the distribution packages and publishes them to TestPyPI. This step requires `PEP_0440_match` to be `true`.
+
+#   Before using this action, ensure to configure trusted-publishing for PyPI and TestPyPI as described in the [Packaging Python Projects documentation](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#configuring-trusted-publishing).
+
 # https://docs.github.com/zh/actions/using-workflows/workflow-syntax-for-github-actions
 
 name: Publish Python 🐍 distribution 📦 to PyPI
@@ -10,6 +25,8 @@ on:
 
 jobs:
   check-tag:
+    # https://stackoverflow.com/a/58869470/14140458
+    # https://packaging.python.org/en/latest/specifications/version-specifiers/#appendix-parsing-version-strings-with-regular-expressions
     name: Check Tag
     if: github.ref_type == 'tag' # only publish to PyPI on tag pushes
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -3,7 +3,10 @@
 
 name: Publish Python 🐍 distribution 📦 to PyPI
 
-on: push
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.*'
 
 jobs:
   build:
@@ -34,7 +37,7 @@ jobs:
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
-    if: startsWith(github.ref, 'refs/tags/') # only publish to PyPI on tag pushes
+    if: github.ref_type == 'tag' # only publish to PyPI on tag pushes
     needs:
       - build
     runs-on: ubuntu-latest
@@ -44,12 +47,20 @@ jobs:
     permissions:
       id-token: write # IMPORTANT: mandatory for trusted publishing
     steps:
+      - name: Check Tag
+        id: check-tag
+        run: |
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "match=true" >> $GITHUB_OUTPUT
+          fi
       - name: Download all the dists
+        if: steps.check-tag.outputs.match == 'true'
         uses: actions/download-artifact@v3
         with:
           name: python-package-distributions
           path: dist/
       - name: Publish distribution 📦 to PyPI
+        if: steps.check-tag.outputs.match == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
 
   github-release:
@@ -97,6 +108,7 @@ jobs:
 
   publish-to-testpypi:
     name: Publish Python 🐍 distribution 📦 to TestPyPI
+    if: github.ref_type == 'tag'
     needs:
       - build
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,120 @@
+# https://docs.github.com/zh/actions/using-workflows/workflow-syntax-for-github-actions
+# https://docs.github.com/zh/actions/using-workflows/workflow-syntax-for-github-actions
+
+name: Publish Python 🐍 distribution 📦 to PyPI
+
+on: push
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Install pypa/build
+        run: >-
+          python3 -m
+          pip install
+          build
+          --user
+      - name: Build a binary wheel and a source tarball
+        run: python3 -m build
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/') # only publish to PyPI on tag pushes
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/recoverable-async-task
+    permissions:
+      id-token: write # IMPORTANT: mandatory for trusted publishing
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: >-
+      Sign the Python 🐍 distribution 📦 with Sigstore
+      and upload them to GitHub Release
+    needs:
+      - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write # IMPORTANT: mandatory for sigstore
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Sign the dists with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v1.2.3
+        with:
+          inputs: >-
+            ./dist/*.tar.gz
+            ./dist/*.whl
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create
+          '${{ github.ref_name }}'
+          --repo '${{ github.repository }}'
+          --notes ""
+      - name: Upload artifact signatures to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        # Upload to GitHub Release using the `gh` CLI.
+        # `dist/` contains the built packages, and the
+        # sigstore-produced signatures and certificates.
+        run: >-
+          gh release upload
+          '${{ github.ref_name }}' dist/**
+          --repo '${{ github.repository }}'
+
+  publish-to-testpypi:
+    name: Publish Python 🐍 distribution 📦 to TestPyPI
+    needs:
+      - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/recoverable-async-task
+
+    permissions:
+      id-token: write # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -12,7 +12,9 @@
 
 #   5. **Publish to TestPyPI**: If the tag complies with the PEP 440 specification but is not a final version, such as containing development versions or pre-release versions, the built distribution packages are published to TestPyPI. This step downloads the distribution packages and publishes them to TestPyPI. This step requires `PEP_0440_match` to be `true`.
 
-#   Before using this action, ensure to configure trusted-publishing for PyPI and TestPyPI as described in the [Packaging Python Projects documentation](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#configuring-trusted-publishing).
+#   Before using this action, ensure to configure trusted-publishing for PyPI and TestPyPI
+#   as described in the [Packaging Python Projects documentation](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#configuring-trusted-publishing).
+#   and modify the PYPI_PROJECT_NAME environment variable accordingly.
 
 # https://docs.github.com/zh/actions/using-workflows/workflow-syntax-for-github-actions
 
@@ -22,6 +24,9 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.*'
+
+env:
+  PYPI_PROJECT_NAME: recoverable-async-task
 
 jobs:
   check-tag:
@@ -79,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/recoverable-async-task
+      url: https://pypi.org/p/${{ env.PYPI_PROJECT_NAME }}
     permissions:
       id-token: write # IMPORTANT: mandatory for trusted publishing
     steps:
@@ -155,7 +160,7 @@ jobs:
 
     environment:
       name: testpypi
-      url: https://test.pypi.org/p/recoverable-async-task
+      url: https://test.pypi.org/p/${{ env.PYPI_PROJECT_NAME }}
 
     permissions:
       id-token: write # IMPORTANT: mandatory for trusted publishing


### PR DESCRIPTION
This GitHub Actions Workflow is designed to automate the publishing of Python distribution packages to PyPI. It triggers on commits with annotated tags that follow the PEP 440 versioning semantics.

The Workflow consists of the following steps:

1. **Check Tag**: Validates if the submitted tag conforms to the PEP 440 versioning semantic specification.
2. **Build Distribution Package**: Builds binary wheels and source tarballs using pypa/build.
3. **Publish to PyPI**: Publishes the built distribution packages to PyPI, provided the tag conforms to the PEP 440 final versioning semantic.
4. **GitHub Release**: Signs the distribution packages with Sigstore and uploads them to GitHub Release.
5. **Publish to TestPyPI**: Publishes the built distribution packages to TestPyPI if the tag conforms to the PEP 440 specification.

This Workflow aims to streamline the release process for Python projects, ensuring the reliability and security of distribution packages.

---

这个 GitHub Actions Workflow 旨在自动发布 Python 分发包到 PyPI。它会在推送带有标签的提交时触发，标签格式需符合 PEP 440 版本语义。

Workflow 主要分为以下几个步骤：

1. **检查标签**：验证提交的标签是否符合 PEP 440 版本语义规范。
2. **构建分发包**：使用 pypa/build 构建二进制 wheel 和源码 tarball。
3. **发布到 PyPI**：将构建好的分发包发布到 PyPI 上，前提是标签符合 PEP 440 最终版语义规范。
4. **GitHub Release**：使用 Sigstore 对分发包进行签名，并将它们上传到 GitHub Release。
5. **发布到 TestPyPI**：如果标签符合 PEP 440 规范，则将构建好的分发包发布到 TestPyPI。

该 Workflow 旨在简化 Python 项目的发布流程，确保分发包的可靠性和安全性。
